### PR TITLE
added post of IDLE mode on run stop

### DIFF
--- a/hcam_drivers/utils/hcam.py
+++ b/hcam_drivers/utils/hcam.py
@@ -176,7 +176,7 @@ class InstPars(tk.LabelFrame):
         self.number.grid(row=7, column=1, pady=2, sticky=tk.W)
 
         # nb, ng, nr etc
-        labels = ('nb', 'ng', 'nr', 'ni', 'nz')
+        labels = ('nu', 'ng', 'nr', 'ni', 'nz')
         ivals = (1, 1, 1, 1, 1)
         imins = (1, 1, 1, 1, 1)
         imaxs = (20, 20, 20, 20, 20)

--- a/hcam_drivers/utils/obsmodes.py
+++ b/hcam_drivers/utils/obsmodes.py
@@ -29,7 +29,7 @@ class ObsMode(object):
             Dictionary of HiPerCAM setup data
         """
         app_data = setup_data['appdata']
-        nb, ng, nr, ni, nz = app_data['multipliers']
+        nu, ng, nr, ni, nz = app_data['multipliers']
         dummy = app_data.get('dummy_out', 0)  # works even if dummy not set in app, default 0
         self.detpars = {
             'DET.BINX1': app_data['xbin'],
@@ -40,7 +40,7 @@ class ObsMode(object):
             'DET.EXPLED': 'T' if app_data['led_flsh'] else 'F',
             'DET.GPS': 'T',
             'DET.INCPRSCX': 'T' if app_data['oscan'] else 'F',
-            'DET.NSKIPS1': nb-1,
+            'DET.NSKIPS1': nu-1,
             'DET.NSKIPS2': ng-1,
             'DET.NSKIPS3': nr-1,
             'DET.NSKIPS4': ni-1,
@@ -78,6 +78,7 @@ class Idle(ObsMode):
             'clear': True,
             'led_flsh': False,
             'oscan': False,
+            'multipliers': (1, 1, 1, 1, 1),
             'exptime': 10
         }
         setup_data = {'appdata': app_data}

--- a/hcam_drivers/utils/widgets.py
+++ b/hcam_drivers/utils/widgets.py
@@ -19,7 +19,7 @@ from .tkutils import get_root
 from .logs import Logger, GuiHandler
 from .astro import calc_riseset
 from .misc import (execCommand, checkSimbad, isRunActive,
-                   getRunNumber, getFrameNumber)
+                   getRunNumber, postJSON, getFrameNumber)
 
 
 # GENERAL UI WIDGETS
@@ -1533,6 +1533,16 @@ class Stop(ActButton):
                     # Report that run has stopped
                     g.clog.info('Run stopped')
                     self.stopped_ok = True
+                    
+                    idle = {'appdata': {'app': 'Idle'}}
+                    try:
+                        success = postJSON(g, idle)
+                        if not success:
+                            raise Exception('postJSON returned false')
+                    except Exception as err:
+                        g.clog.warn('Failed to enable idle mode')
+                        g.clog.warn(str(err))
+                        
                 else:
                     g.clog.warn('Failed to stop run')
                     self.stopped_ok = False


### PR DESCRIPTION
Fixes #9 

After a run has successfully stopped an idle mode is posted, which loads in a 10s full frame mode with clear enabled and gps time stamping turned off.

Not tested yet, do not merge until it is. 