### PR TITLE
Migrate serial-based hardware to TCP/IP Termserver devices

### DIFF
--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -122,7 +122,7 @@ class Slide(object):
         return bytearray(msg)
 
     def _decodeCommandData(self, byteArr):
-        return struct.unpack('<L', bytes(byteArr[2:])[0]
+        return struct.unpack('<L', bytes(byteArr[2:]))[0]
 
     def _encodeCommandData(self, int):
         return bytearray(struct.pack('<L', int))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -122,7 +122,7 @@ class Slide(object):
         return msg
 
     def _decodeCommandData(self, byteArr):
-        return struct.unpack('<L', byteArr[2:])[0]
+        return struct.unpack('<L', byteArr[2:].decode())[0]
 
     def _encodeCommandData(self, int):
         return bytearray(struct.pack('<L', int))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -5,7 +5,7 @@ Class to talk to the focal plane slide
 
 Written by Stu.
 """
-from __future__ import (print_function, unicode_literals, division, absolute_import)
+from __future__ import (print_function, division, absolute_import)
 import serial
 import struct
 import six
@@ -122,7 +122,7 @@ class Slide(object):
         return bytearray(msg)
 
     def _decodeCommandData(self, byteArr):
-        return struct.unpack('<L', bytes(byteArr[2:]))[0]
+        return struct.unpack('<L', byteArr[2:])[0]
 
     def _encodeCommandData(self, int):
         return bytearray(struct.pack('<L', int))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -87,7 +87,7 @@ MS_PER_STEP = 64
 
 # MAX_TIMEOUT is set by the time taken to move the slide from one end to the
 # other MIN_TIMEOUT is used as a lower limt on all timeouts (seconds)
-MIN_TIMEOUT = 2
+MIN_TIMEOUT = 5
 MAX_TIMEOUT = 70
 
 

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -111,14 +111,14 @@ class Slide(object):
             self.log = log
 
     def _sendRecv(self, byteArr, timeout):
-        with netdevice(self.host, self.port, timeout) as dev:
+        with netdevice(self.host, self.port) as dev:
             try:
+                dev.settimeout(timeout)
                 dev.send(byteArr)
             except Exception as e:
                 raise SlideError('failed to send bytes to slide' + str(e))
+            dev.settimeout(timeout)
             msg = dev.recv(6)
-            if len(msg) != 6:
-                raise SlideError('slide failed to return 6 bytes')
         return msg
 
     def _decodeCommandData(self, byteArr):

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -113,7 +113,7 @@ class Slide(object):
     def _sendRecv(self, byteArr, timeout):
         with netdevice(self.host, self.port) as dev:
             try:
-                dev.settimeout(timeout)
+                dev.settimeout(self.default_timeout)
                 dev.send(byteArr)
             except Exception as e:
                 raise SlideError('failed to send bytes to slide' + str(e))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -19,6 +19,7 @@ from ..utils.logs import Logger
 from ..utils.widgets import GuiLogger, IntegerEntry
 from ..utils.misc import FifoThread
 from ..utils.tkutils import get_root
+from .termserver import netdevice
 
 
 class SlideError(Exception):
@@ -92,7 +93,7 @@ MAX_TIMEOUT = 70
 
 class Slide(object):
 
-    def __init__(self, log=None, port='/dev/slide'):
+    def __init__(self, log=None, host='195.194.120.72', port=10002):
         """
         Creates a Slide. Arguments::
 
@@ -102,46 +103,21 @@ class Slide(object):
 
         """
         self.port = port
+        self.host = host
         self.default_timeout = MIN_TIMEOUT
-        self.connected = False
         if log is None:
             self.log = Logger('SLD')
         else:
             self.log = log
 
-    def _open_port(self):
-        try:
-            self.ser = serial.Serial(self.port, baudrate=9600)
-            self.connected = True
-        except:
-            self.connected = False
-
-    def _close_port(self):
-        try:
-            self.ser.close()
-            self.connected = False
-        except Exception as e:
-            raise SlideError(e)
-
-    def _sendByteArr(self, byteArr, timeout):
-        if self.connected:
-            self.ser.timeout = timeout
-            bytes_sent = self.ser.write(byteArr)
-            if bytes_sent != 6:
-                raise SlideError('failed to send bytes to slide')
-        else:
-            raise SlideError('cannot send bytes to an unconnected slide')
-
-    def _readBytes(self, timeout):
-        if self.connected:
-            self.ser.timeout = timeout
-            bytes = self.ser.read(6)
-            byteArr = bytearray(bytes)
-            if len(byteArr) != 6:
-                raise SlideError('did not get 6 bytes back from slide')
-            return byteArr
-        else:
-            raise SlideError('cannot send bytes to an unconnected slide')
+    def _sendRecv(self, byteArr, timeout):
+        with netdevice(self.host, self.port, timeout) as dev:
+            try:
+                dev.send(byteArr)
+                msg = dev.recv(6)
+            except Exception as e:
+                raise SlideError('failed to send bytes to slide' + str(e))
+        return msg
 
     def _decodeCommandData(self, byteArr):
         return struct.unpack('<L', byteArr[2:])[0]
@@ -175,12 +151,8 @@ class Slide(object):
         """
         if not self._hasBeenHomed():
             raise SlideError('position of slide is undefined until slide homed')
-        if not self.connected:
-            self._open_port()
         byteArr = self._encodeByteArr([UNIT, POSITION, NULL, NULL, NULL, NULL])
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         pos = self._decodeCommandData(byteArr)
         return pos
 
@@ -189,13 +161,9 @@ class Slide(object):
         returns true if the slide has been homed and has a calibrated
         position
         """
-        if not self.connected:
-            self._open_port()
         byteArr = self._encodeByteArr([UNIT, RETURN_SETTING,
                                        SET_MODE, NULL, NULL, NULL])
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         if byteArr[1] == ERROR:
             raise SlideError('Error trying to get the setting byte')
 
@@ -223,11 +191,7 @@ class Slide(object):
         # add bytes to define instruction at start of array
         byteArr.insert(0, chr(MOVE_ABSOLUTE))
         byteArr.insert(0, chr(UNIT))
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, timeout)
 
     def _move_relative(self, nstep, timeout=None):
         """
@@ -250,11 +214,7 @@ class Slide(object):
         # add bytes to define instruction at start of array
         byteArr.insert(0, chr(MOVE_RELATIVE))
         byteArr.insert(0, chr(UNIT))
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
 
     def _convert_to_microstep(self, amount, units):
         """"
@@ -304,11 +264,7 @@ class Slide(object):
             timeout = self.time_home()
 
         byteArr = self._encodeByteArr([UNIT, HOME, NULL, NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         if byteArr[1] == ERROR:
             raise SlideError('Error occurred setting to the home position')
         self.log.info('Slide returned to home position ' +
@@ -321,11 +277,7 @@ class Slide(object):
         needed
         """
         byteArr = self._encodeByteArr([UNIT, RESET, NULL, NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         return byteArr
 
     def restore(self):
@@ -335,11 +287,7 @@ class Slide(object):
         """
         byteArr = self._encodeByteArr([UNIT, RESTORE, PERIPHERAL_ID,
                                        NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         self.log.info('finished restore')
         return byteArr
 
@@ -350,11 +298,7 @@ class Slide(object):
         """
         byteArr = self._encodeByteArr([UNIT, SET_MODE, POTENTIOM_OFF,
                                        NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         self.log.info('manual adjustment disabled')
         return byteArr
 
@@ -365,22 +309,14 @@ class Slide(object):
         """
         byteArr = self._encodeByteArr([UNIT, SET_MODE, POTENTIOM_ON,
                                        NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         self.log.info('manual adjustment enabled')
         return byteArr
 
     def stop(self):
         """stop the slide"""
         byteArr = self._encodeByteArr([UNIT, STOP, NULL, NULL, NULL, NULL])
-        if not self.connected:
-            self._open_port()
-        self._sendByteArr(byteArr, self.default_timeout)
-        byteArr = self._readBytes(timeout=self.default_timeout)
-        self._close_port()
+        byteArr = self._sendRecv(byteArr, self.default_timeout)
         if byteArr[1] == ERROR:
             raise SlideError('Error stopping the slide')
         else:

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -119,7 +119,7 @@ class Slide(object):
                 raise SlideError('failed to send bytes to slide' + str(e))
             dev.settimeout(timeout)
             msg = dev.recv(6)
-        return bytearray(msg)
+        return bytes(msg)
 
     def _decodeCommandData(self, byteArr):
         return struct.unpack('<L', byteArr[2:])[0]

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -119,10 +119,10 @@ class Slide(object):
                 raise SlideError('failed to send bytes to slide' + str(e))
             dev.settimeout(timeout)
             msg = dev.recv(6)
-        return msg
+        return bytearray(msg)
 
     def _decodeCommandData(self, byteArr):
-        return struct.unpack('<L', byteArr[2:].decode())[0]
+        return struct.unpack('<L', byteArr[2:])[0]
 
     def _encodeCommandData(self, int):
         return bytearray(struct.pack('<L', int))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -119,10 +119,10 @@ class Slide(object):
                 raise SlideError('failed to send bytes to slide' + str(e))
             dev.settimeout(timeout)
             msg = dev.recv(6)
-        return bytes(msg)
+        return bytearray(msg)
 
     def _decodeCommandData(self, byteArr):
-        return struct.unpack('<L', byteArr[2:])[0]
+        return struct.unpack('<L', bytes(byteArr[2:])[0]
 
     def _encodeCommandData(self, int):
         return bytearray(struct.pack('<L', int))

--- a/hcam_drivers/hardware/slide.py
+++ b/hcam_drivers/hardware/slide.py
@@ -114,9 +114,11 @@ class Slide(object):
         with netdevice(self.host, self.port, timeout) as dev:
             try:
                 dev.send(byteArr)
-                msg = dev.recv(6)
             except Exception as e:
                 raise SlideError('failed to send bytes to slide' + str(e))
+            msg = dev.recv(6)
+            if len(msg) != 6:
+                raise SlideError('slide failed to return 6 bytes')
         return msg
 
     def _decodeCommandData(self, byteArr):

--- a/hcam_drivers/hardware/termserver.py
+++ b/hcam_drivers/hardware/termserver.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+"""
+Provides a context manager for talking to serial devices over term server
+"""
+from __future__ import (print_function, unicode_literals, division, absolute_import)
+import socket
+from contextlib import contextmanager
+
+@contextmanager
+def netdevice(host, port, timeout=5):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect((host, port))
+        s.settimeout(timeout)
+        yield s
+    finally:
+        s.close()

--- a/hcam_drivers/hardware/vacuum.py
+++ b/hcam_drivers/hardware/vacuum.py
@@ -9,6 +9,8 @@ from astropy.time import Time, TimeDelta
 from astropy.io import ascii
 from astropy import units as u
 
+from .termserver import netdevice
+
 DEFAULT_TIMEOUT = 0.5  # seconds
 
 # MESSAGES (as strings, don't forget to format and encode)
@@ -18,6 +20,7 @@ FIRMWARE = '@{addr}FVC{comm};FF'
 ADDRESS = '@{addr}ADC{comm};FF'
 DLOG_CTRL = '@{addr}DLC{comm};FF'
 DLOG_TIME = '@{addr}DLT{comm};FF'
+PRESSURE = '@{addr}PR1{comm};FF'
 
 
 class VacuumGaugeError(Exception):
@@ -26,7 +29,7 @@ class VacuumGaugeError(Exception):
 
 class PDR900(object):
 
-    def __init__(self, port='/dev/pdr900'):
+    def __init__(self, host='195.194.120.72', port=10002):
         """
         Creates a PDR900 object for communication over serial.
 
@@ -36,7 +39,7 @@ class PDR900(object):
             port device representing the vacuum gauge
         """
         self.port = port
-        self.connected = False
+        self.host = host
         self.logging_start_time = None
 
         # connect once to find address and hard-code
@@ -44,44 +47,20 @@ class PDR900(object):
         _, addr = self._send_recv(ADDRESS, data)
         self.address = addr
 
-    def _open_port(self):
-        try:
-            self.ser = serial.Serial(self.port, baudrate=9600)
-            self.connected = True
-        except:
-            self.connected = False
-
-    def _close_port(self):
-        try:
-            self.ser.close()
-            self.connected = False
-        except Exception as e:
-            raise VacuumGaugeError(e)
-
     def _send_bytes(self, msg, timeout=DEFAULT_TIMEOUT):
-        if self.connected:
-            self.ser.timeout = timeout
-            bytes_sent = self.ser.write(msg)
-            if bytes_sent != len(msg):
-                raise VacuumGaugeError('failed to send bytes to gauge')
-        else:
-            raise VacuumGaugeError('cannot send bytes to an unconnected gauge')
+        with netdevice(self.host, self.port, timeout) as dev:
+            try:
+                dev.send(msg)
+            except Exception as e:
+                raise VacuumGaugeError(str(e))
 
     def _read_response(self, timeout=DEFAULT_TIMEOUT):
-        start = time.time()
-        response = bytearray()
-        timed_out = True
-        while (time.time() - start < timeout):
-            response.extend(self.ser.read())
-            if len(response) >= 3 and response[-3:] == b';FF':
-                # we have got an end msg
-                timed_out = False
-                break
-
-        # did we timeout
-        if timed_out:
-            raise VacuumGaugeError('timed out reading response on port {}'.format(self.port))
-        return response.decode()
+        with netdevice(self.host, self.port, timeout) as dev:
+            try:
+                msg = dev.recv(1024)
+            except Exception as e:
+                raise VacuumGaugeError(str(e))
+            return msg.rstrip('\r\n')
 
     def _parse_response(self, response):
         pattern = '@(.*)ACK(.*);FF'
@@ -97,12 +76,9 @@ class PDR900(object):
         return result.groups()
 
     def _send_recv(self, message, data):
-        if not self.connected:
-            self._open_port()
         msg = message.format(**data).encode()
         self._send_bytes(msg)
         response = self._read_response()
-        self._close_port()
         addr, retval = self._parse_response(response)
         return addr, retval
 


### PR DESCRIPTION
This adds code to talk to serial devices over TCP/IP, allowing the devices to be anywhere on the hipercam network