### PR TITLE
increase numproc and nq for drift mode

### DIFF
--- a/hcam_drivers/utils/obsmodes.py
+++ b/hcam_drivers/utils/obsmodes.py
@@ -187,7 +187,7 @@ class ObsMode(object):
 
     @property
     def acq_command(self):
-        template = 'acqproc hiperCamCCD -chip 5 -t 2 -nq {nq} -deml 0 -gps {gps} -aveg {aveg} -aps 8 -drf {drf}'
+        template = 'acqproc hiperCamCCD -chip 5 -t 4 -nq {nq} -deml 0 -gps {gps} -aveg {aveg} -aps 8 -drf {drf}'
         return template.format(**self.acq_dict)
 
     @property
@@ -333,7 +333,7 @@ class Drift(ObsMode):
         self.detpars.update(win1)
         self.nrows = 520  # number of rows in storage area
         self.readoutMode = 4
-        self.setup_acq_task(nq=200)
+        self.setup_acq_task(nq=800)
 
     @property
     def num_stacked(self):


### PR DESCRIPTION
This is one of two pull requests that will fix https://github.com/HiPERCAM/hiperCamCCD/issues/7

Here we make sure that the acquisition process is always launched using 4 threads, an increase from the default of 2. We also increase ```nq``` for drift mode.