### PR TITLE
add runpars to list of widgets with expert mode

### DIFF
--- a/scripts/hdriver
+++ b/scripts/hdriver
@@ -137,7 +137,7 @@ class GUI(tk.Tk):
 
         # expert settingsMenu
         expertMenu = w.ExpertMenu(settingsMenu, self.globals.observe, self.globals.setup,
-                                  self.globals.ipars,
+                                  self.globals.ipars, self.globals.rpars,
                                   self.globals.fpslide, switch)
         settingsMenu.add_cascade(label='Expert', menu=expertMenu)
 


### PR DESCRIPTION
Closes #134 in combination with  https://github.com/HiPERCAM/hcam_widgets/pull/13.

The linked PR above adds all the functionality, but we have to add the ```RunPars``` widget to the list of those affected by expert mode.