### PR TITLE
No ngc statemachine

### DIFF
--- a/scripts/hdriver
+++ b/scripts/hdriver
@@ -290,7 +290,7 @@ class GUI(tk.Tk):
             if bring_offline:
                 # attempt to power off server
                 try:
-                    result = yield execCommand(self.globals, 'ngc_server.offline')
+                    result = yield execCommand(self.globals, 'offline')
                 except:
                     result = False
                 if result:

--- a/scripts/start_hicam
+++ b/scripts/start_hicam
@@ -107,10 +107,12 @@ fi
 
 sleep 2
 
-# move server into offline state (starting NGC software in process)
-sleep 2
-do_wamp_call hipercam.ngc.rpc.ngc_server.offline
+# relaunch NGC server software
+do_wamp_call hipercam.ngc.rpc.stop_ngc_server
+do_wamp_call hipercam.ngc.rpc.start_ngc_server
+do_wamp_call hipercam.ngc.rpc.offline
 sleep 1
 
 # load default setup and switch to standby mode
+do_wamp_call hiperca.ngc.rpc.setup_ngc_server
 do_wamp_call hipercam.ngc.rpc.ngc_server.standby

--- a/scripts/start_hicam
+++ b/scripts/start_hicam
@@ -114,5 +114,5 @@ do_wamp_call hipercam.ngc.rpc.offline
 sleep 1
 
 # load default setup and switch to standby mode
-do_wamp_call hiperca.ngc.rpc.setup_ngc_server
-do_wamp_call hipercam.ngc.rpc.ngc_server.standby
+do_wamp_call hipercam.ngc.rpc.setup_ngc_server
+do_wamp_call hipercam.ngc.rpc.standby

--- a/scripts/stop_hicam
+++ b/scripts/stop_hicam
@@ -48,7 +48,7 @@ def kill_script(name):
 
 def shutdown_eso_software():
     try:
-        call('hipercam.ngc.rpc.ngc_server.exit')
+        call('hipercam.ngc.rpc.stop_ngc_server')
     except Exception as err:
         print('could not shut down eso software - ' + repr(err))
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
         # default call, shutdown ESO s/w and everything EXCEPT hwserver
         for script in ['hserver', 'gtcserver', 'hdriver', 'fileserver']:
             kill_script(script)
-        
+
     else:
         for program in programs:
             if program not in KNOWN_SCRIPTS and program != 'eso':


### PR DESCRIPTION
In https://github.com/HiPERCAM/hcam_devices/pull/12, we removed the NGC statemachine. This PR makes the required changes to hcam_drivers to handle this change 